### PR TITLE
added tests for return of item setters

### DIFF
--- a/src/CachePoolTest.php
+++ b/src/CachePoolTest.php
@@ -106,6 +106,20 @@ abstract class CachePoolTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->cache->getItem('key2')->isHit());
     }
 
+    public function testItemModifiersReturnsStatic()
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+
+            return;
+        }
+
+        $item = $this->cache->getItem('key');
+        $this->assertSame($item, $item->set('4711'));
+        $this->assertSame($item, $item->expiresAfter(2));
+        $this->assertSame($item, $item->expiredAt(new \DateTime('+2hours')));
+    }
+
     public function testGetItem()
     {
         if (isset($this->skippedTests[__FUNCTION__])) {


### PR DESCRIPTION
Is this true?

I have a implementation for PSR-6 and I think that the Interface docblock says to return the instance.

It would allow to use the form:

``` php
$item = $cache->get('key')->set('value');
$cache->save($item);
```

Also not sure the version requirement for PHPUnit and _assertSame()_
Thanks for the good work
