### PR TITLE
Speedup tests with clock mock

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
     ],
     "require":     {
         "php":       "^5.4|^7",
-        "psr/cache": "~1.0"
+        "psr/cache": "~1.0",
+        "symfony/phpunit-bridge": "^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.0|^5.0"


### PR DESCRIPTION
This will speedup tests by introducing clock mock. We will no longer sleep for 10 seconds when we do `sleep(10)`.

This will also add test for https://github.com/php-cache/issues/issues/1
