### PR TITLE
Speedup tests with clock mock

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
     ],
     "require":     {
         "php":       "^5.4|^7",
-        "psr/cache": "~1.0"
+        "psr/cache": "~1.0",
+        "symfony/phpunit-bridge": "^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.0|^5.0",

--- a/src/CachePoolTest.php
+++ b/src/CachePoolTest.php
@@ -35,6 +35,10 @@ abstract class CachePoolTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $this->cache = $this->createCachePool();
+
+        ClockMock::register(__CLASS__);
+        ClockMock::register(get_class($this->cache));
+        ClockMock::withClockMock(true);
     }
 
     protected function tearDown()
@@ -42,16 +46,7 @@ abstract class CachePoolTest extends \PHPUnit_Framework_TestCase
         if ($this->cache !== null) {
             $this->cache->clear();
         }
-    }
 
-    public static function setUpBeforeClass()
-    {
-        ClockMock::register(__CLASS__);
-        ClockMock::withClockMock(true);
-    }
-
-    public static function tearDownAfterClass()
-    {
         ClockMock::withClockMock(false);
     }
 

--- a/src/CachePoolTest.php
+++ b/src/CachePoolTest.php
@@ -23,6 +23,11 @@ abstract class CachePoolTest extends \PHPUnit_Framework_TestCase
     protected $skippedTests = [];
 
     /**
+     * @type bool
+     */
+    protected $skipClockMock = false;
+
+    /**
      * @type CacheItemPoolInterface
      */
     private $cache;
@@ -36,9 +41,11 @@ abstract class CachePoolTest extends \PHPUnit_Framework_TestCase
     {
         $this->cache = $this->createCachePool();
 
-        ClockMock::register(__CLASS__);
-        ClockMock::register(get_class($this->cache));
-        ClockMock::withClockMock(true);
+        if (!$this->skipClockMock) {
+            ClockMock::register(__CLASS__);
+            ClockMock::register(get_class($this->cache));
+            ClockMock::withClockMock(true);
+        }
     }
 
     protected function tearDown()
@@ -47,7 +54,9 @@ abstract class CachePoolTest extends \PHPUnit_Framework_TestCase
             $this->cache->clear();
         }
 
-        ClockMock::withClockMock(false);
+        if (!$this->skipClockMock) {
+            ClockMock::withClockMock(false);
+        }
     }
 
     /**


### PR DESCRIPTION
Replaces #49

Since the class under test is in a different namespace than the test case, both need to be registered manually.

Note that [one of your tests in php-cache/cache will still fail](https://github.com/php-cache/cache/blob/61e4d4939db308f506f143fa05350bc29f33b854/src/Adapter/Filesystem/Tests/FilesystemCachePoolTest.php#L31-L46) as it doesn't use the setup from tests cases here. That project needs to configure clockmock on its own.
