### PR TITLE
Add integration test for untested situation

### DIFF
--- a/src/CachePoolTest.php
+++ b/src/CachePoolTest.php
@@ -876,4 +876,21 @@ abstract class CachePoolTest extends \PHPUnit_Framework_TestCase
         $value = $item->get();
         $this->assertInstanceOf('DateTime', $value, 'You must be able to store objects in cache.');
     }
+
+    public function testHasItemReturnsFalseWhenDeferredItemIsExpired()
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+
+            return;
+        }
+
+        $item = $this->cache->getItem('key');
+        $item->set('value');
+        $item->expiresAfter(2);
+        $this->cache->saveDeferred($item);
+
+        sleep(3);
+        $this->assertFalse($this->cache->hasItem('key'));
+    }
 }


### PR DESCRIPTION
I noticed one line of my implementation test didn't get tested by both my own unit tests and these integration tests.

<img width="606" alt="screen shot 2016-07-03 at 22 40 13" src="https://cloud.githubusercontent.com/assets/1410358/16547473/2822be36-416f-11e6-9e81-46d68f6e2057.png">

This should fix that.
Source code: [github.com/madewithlove/illuminate-psr-cache-bridge](github.com/madewithlove/illuminate-psr-cache-bridge)
