### PR TITLE
Remove iteration when expecting exception for SimpleCache::getMultiple

### DIFF
--- a/src/SimpleCacheTest.php
+++ b/src/SimpleCacheTest.php
@@ -362,10 +362,7 @@ abstract class SimpleCacheTest extends \PHPUnit_Framework_TestCase
             $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
         }
 
-        $result = $this->cache->getMultiple(['key1', $key, 'key2']);
-        foreach ($result as $r) {
-            // We want to make sure we iterate over the results
-        }
+        $this->cache->getMultiple(['key1', $key, 'key2']);
     }
 
     /**
@@ -377,10 +374,7 @@ abstract class SimpleCacheTest extends \PHPUnit_Framework_TestCase
             $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
         }
 
-        $result = $this->cache->getMultiple('key');
-        foreach ($result as $r) {
-            // We want to make sure we iterate over the results
-        }
+        $this->cache->getMultiple('key');
     }
 
     /**


### PR DESCRIPTION
PSR-16 requires that the exception for invalid keys is thrown by ``getMultiple``, not by the iteration over the result (which can be done much later). So the testsuite must enforce it (it already enforces it properly in PSR-6 tests).