### PR TITLE
Separate out test for integer-castable string key used in testSetMultiple

### DIFF
--- a/src/SimpleCacheTest.php
+++ b/src/SimpleCacheTest.php
@@ -215,6 +215,17 @@ abstract class SimpleCacheTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('value1', $this->cache->get('key1'));
     }
 
+    public function testSetMultipleWithIntegerArrayKey()
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $result = $this->cache->setMultiple(['0' => 'value0']);
+        $this->assertTrue($result, 'setMultiple() must return true if success');
+        $this->assertEquals('value0', $this->cache->get('0'));
+    }
+
     public function testSetMultipleTtl()
     {
         if (isset($this->skippedTests[__FUNCTION__])) {

--- a/src/SimpleCacheTest.php
+++ b/src/SimpleCacheTest.php
@@ -214,9 +214,10 @@ abstract class SimpleCacheTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('value0', $this->cache->get('key0'));
         $this->assertEquals('value1', $this->cache->get('key1'));
 
-        $result = $this->cache->setMultiple(['0' => 'value0']);
-        $this->assertTrue($result, 'setMultiple() must return true if success');
-        $this->assertEquals('value0', $this->cache->get('0'));
+//@todo PHP casts '0' to an integer, so this test will never pass
+//        $result = $this->cache->setMultiple(['0' => 'value0']);
+//        $this->assertTrue($result, 'setMultiple() must return true if success');
+//        $this->assertEquals('value0', $this->cache->get('0'));
     }
 
     public function testSetMultipleTtl()

--- a/src/SimpleCacheTest.php
+++ b/src/SimpleCacheTest.php
@@ -213,11 +213,6 @@ abstract class SimpleCacheTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($result, 'setMultiple() must return true if success');
         $this->assertEquals('value0', $this->cache->get('key0'));
         $this->assertEquals('value1', $this->cache->get('key1'));
-
-//@todo PHP casts '0' to an integer, so this test will never pass
-//        $result = $this->cache->setMultiple(['0' => 'value0']);
-//        $this->assertTrue($result, 'setMultiple() must return true if success');
-//        $this->assertEquals('value0', $this->cache->get('0'));
     }
 
     public function testSetMultipleTtl()


### PR DESCRIPTION
Having to open a PR here to highlight the problem; basically, `SimpleCacheTest#testSetMultiple` has an issue using `'0'` as a string key.

As described here:
 * https://twitter.com/derickr/status/822025899767922688
 * https://twitter.com/MrDanack/status/822025166133882880
 * https://stackoverflow.com/questions/4100488/a-numeric-string-as-array-key-in-php

This key will *always* be cast to `int(0)` rather than kept as a `string`. Therefore, this specific test will never actually be able to pass, as according to the PSR-16 spec, an integer key is not permitted.