### PR TITLE
Add tests for binary data round trip

### DIFF
--- a/src/CachePoolTest.php
+++ b/src/CachePoolTest.php
@@ -776,6 +776,27 @@ abstract class CachePoolTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($item->isHit(), 'isHit() should return true when object are stored. ');
     }
 
+    public function testBinaryData()
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+
+            return;
+        }
+
+        $data = '';
+        for ($i = 0; $i < 256; $i++) {
+            $data .= chr($i);
+        }
+
+        $item = $this->cache->getItem('key');
+        $item->set($data);
+        $this->cache->save($item);
+
+        $item = $this->cache->getItem('key');
+        $this->assertTrue($data === $item->get(), 'Binary data must survive a round trip.');
+    }
+
     public function testIsHit()
     {
         if (isset($this->skippedTests[__FUNCTION__])) {

--- a/src/SimpleCacheTest.php
+++ b/src/SimpleCacheTest.php
@@ -620,6 +620,23 @@ abstract class SimpleCacheTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($object, $result);
     }
 
+    public function testBinaryData()
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $data = '';
+        for ($i = 0; $i < 256; $i++) {
+            $data .= chr($i);
+        }
+
+        $array = ['a' => 'foo', 2 => 'bar'];
+        $this->cache->set('key', $data);
+        $result = $this->cache->get('key');
+        $this->assertTrue($data === $result, 'Binary data must survive a round trip.');
+    }
+
     /**
      * @dataProvider validKeys
      */


### PR DESCRIPTION
This is related to pull request [php-cache/cache#188](https://github.com/php-cache/cache/pull/188).

This adds core tests to ensure that binary data is properly round-tripped by each adapter and component.

Currently this test reveals the following existing bugs:

* EncryptedCacheItem silently fails in json_encode if passed binary data
* The MongoDB adapter cannot save binary data because it is invalid JSON

I will be updating [php-cache/cache#188](https://github.com/php-cache/cache/pull/188) with fixes to these revealed issues.