### PR TITLE
Allow adding tests

### DIFF
--- a/src/CachePoolTest.php
+++ b/src/CachePoolTest.php
@@ -25,7 +25,7 @@ abstract class CachePoolTest extends TestCase
     /**
      * @type CacheItemPoolInterface
      */
-    private $cache;
+    protected $cache;
 
     /**
      * @return CacheItemPoolInterface that is used in the tests

--- a/src/HierarchicalCachePoolTest.php
+++ b/src/HierarchicalCachePoolTest.php
@@ -27,7 +27,7 @@ abstract class HierarchicalCachePoolTest extends TestCase
     /**
      * @type CacheItemPoolInterface
      */
-    private $cache;
+    protected $cache;
 
     /**
      * @return CacheItemPoolInterface that is used in the tests

--- a/src/SimpleCacheTest.php
+++ b/src/SimpleCacheTest.php
@@ -24,7 +24,7 @@ abstract class SimpleCacheTest extends TestCase
     /**
      * @type CacheInterface
      */
-    private $cache;
+    protected $cache;
 
     /**
      * @return CacheInterface that is used in the tests

--- a/src/TaggableCachePoolTest.php
+++ b/src/TaggableCachePoolTest.php
@@ -27,7 +27,7 @@ abstract class TaggableCachePoolTest extends TestCase
     /**
      * @type TaggableCacheItemPoolInterface
      */
-    private $cache;
+    protected $cache;
 
     /**
      * @return TaggableCacheItemPoolInterface that is used in the tests


### PR DESCRIPTION
Make the `cache` property protected, to allow additional tests for a cache implementation.