### PR TITLE
Mark tests that sleep as @medium

### DIFF
--- a/src/CachePoolTest.php
+++ b/src/CachePoolTest.php
@@ -482,6 +482,9 @@ abstract class CachePoolTest extends TestCase
         $this->assertTrue($return, 'commit() should return true even if no items were deferred. ');
     }
 
+    /**
+     * @medium
+     */
     public function testExpiration()
     {
         if (isset($this->skippedTests[__FUNCTION__])) {
@@ -848,6 +851,9 @@ abstract class CachePoolTest extends TestCase
         $this->assertInstanceOf('DateTime', $value, 'You must be able to store objects in cache.');
     }
 
+    /**
+     * @medium
+     */
     public function testHasItemReturnsFalseWhenDeferredItemIsExpired()
     {
         if (isset($this->skippedTests[__FUNCTION__])) {

--- a/src/SimpleCacheTest.php
+++ b/src/SimpleCacheTest.php
@@ -165,6 +165,9 @@ abstract class SimpleCacheTest extends TestCase
         $this->assertEquals('value', $this->cache->get('key'));
     }
 
+    /**
+     * @medium
+     */
     public function testSetTtl()
     {
         if (isset($this->skippedTests[__FUNCTION__])) {
@@ -260,6 +263,9 @@ abstract class SimpleCacheTest extends TestCase
         $this->assertEquals('value0', $this->cache->get('0'));
     }
 
+    /**
+     * @medium
+     */
     public function testSetMultipleTtl()
     {
         if (isset($this->skippedTests[__FUNCTION__])) {

--- a/src/SimpleCacheTest.php
+++ b/src/SimpleCacheTest.php
@@ -171,15 +171,16 @@ abstract class SimpleCacheTest extends TestCase
             $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
         }
 
-        $result = $this->cache->set('key1', 'value', 1);
+        $result = $this->cache->set('key1', 'value', 2);
         $this->assertTrue($result, 'set() must return true if success');
         $this->assertEquals('value', $this->cache->get('key1'));
-        $this->advanceTime(2);
-        $this->assertNull($this->cache->get('key1'), 'Value must expire after ttl.');
 
-        $this->cache->set('key2', 'value', new \DateInterval('PT1S'));
+        $this->cache->set('key2', 'value', new \DateInterval('PT2S'));
         $this->assertEquals('value', $this->cache->get('key2'));
-        $this->advanceTime(2);
+
+        $this->advanceTime(3);
+
+        $this->assertNull($this->cache->get('key1'), 'Value must expire after ttl.');
         $this->assertNull($this->cache->get('key2'), 'Value must expire after ttl.');
     }
 
@@ -265,16 +266,17 @@ abstract class SimpleCacheTest extends TestCase
             $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
         }
 
-        $this->cache->setMultiple(['key2' => 'value2', 'key3' => 'value3'], 1);
+        $this->cache->setMultiple(['key2' => 'value2', 'key3' => 'value3'], 2);
         $this->assertEquals('value2', $this->cache->get('key2'));
         $this->assertEquals('value3', $this->cache->get('key3'));
-        $this->advanceTime(2);
+
+        $this->cache->setMultiple(['key4' => 'value4'], new \DateInterval('PT2S'));
+        $this->assertEquals('value4', $this->cache->get('key4'));
+
+        $this->advanceTime(3);
+
         $this->assertNull($this->cache->get('key2'), 'Value must expire after ttl.');
         $this->assertNull($this->cache->get('key3'), 'Value must expire after ttl.');
-
-        $this->cache->setMultiple(['key4' => 'value4'], new \DateInterval('PT1S'));
-        $this->assertEquals('value4', $this->cache->get('key4'));
-        $this->advanceTime(2);
         $this->assertNull($this->cache->get('key4'), 'Value must expire after ttl.');
     }
 

--- a/src/SimpleCacheTest.php
+++ b/src/SimpleCacheTest.php
@@ -280,7 +280,6 @@ abstract class SimpleCacheTest extends TestCase
         $this->assertEquals('value4', $this->cache->get('key4'));
 
         $this->advanceTime(3);
-
         $this->assertNull($this->cache->get('key2'), 'Value must expire after ttl.');
         $this->assertNull($this->cache->get('key3'), 'Value must expire after ttl.');
         $this->assertNull($this->cache->get('key4'), 'Value must expire after ttl.');


### PR DESCRIPTION
> The `@medium` annotation is an alias for `@group medium`.
> 
> If the PHP_Invoker package is installed and strict mode is enabled, a medium test will fail if it takes longer than 10 seconds to execute. This timeout is configurable via the timeoutForMediumTests attribute in the XML configuration file.

You can skip these tests while developing by running

    phpunit --exclude-group medium

This will significantly speed up the execution of the suite.

Includes PR #80 