### PR TITLE
Test for failure cases

### DIFF
--- a/src/SimpleCacheTest.php
+++ b/src/SimpleCacheTest.php
@@ -27,19 +27,33 @@ abstract class SimpleCacheTest extends TestCase
     protected $cache;
 
     /**
+     * @var CacheInterface
+     */
+    protected $failingCache;
+
+    /**
      * @return CacheInterface that is used in the tests
      */
     abstract public function createSimpleCache();
 
+    /**
+     * @return CacheInterface that is used in tests that check failure cases
+     */
+    abstract public function createFailingSimpleCache();
+
     protected function setUp()
     {
         $this->cache = $this->createSimpleCache();
+        $this->failingCache = $this->createFailingSimpleCache();
     }
 
     protected function tearDown()
     {
         if ($this->cache !== null) {
             $this->cache->clear();
+        }
+        if ($this->failingCache !== null) {
+            $this->failingCache->clear();
         }
     }
 
@@ -753,5 +767,16 @@ abstract class SimpleCacheTest extends TestCase
 
         $cacheObject = $this->cache->get('key');
         $this->assertEquals('value', $cacheObject->foo, 'Object in cache should not have their values changed.');
+    }
+
+    public function testSetFailure()
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $result = $this->failingCache->set('key', 'value');
+        $this->assertFalse($result, 'set() must return false if failure');
+        $this->assertNull($this->cache->get('key'), 'Value should not be set after failure');
     }
 }


### PR DESCRIPTION
Currently none of the tests check failures in the caches. This is meant more of an example of how it might be possible to test these cases. I would expand it if there is seen a value in adding these types of tests.

I think its useful as a not very careful implemention might for example accidentally let exceptions thrown by clients get thrown, instead of catching them and returning false.

I have put an example of how this might be implemented in the Symfony cache component, well - its actually just a quick adding of the test, it would probably look nothing like this in a real version, rather this proves the point. https://github.com/mcfedr/symfony/commit/eec268ec2cef534dd1028b2f5e8768f5a40c1dc2