### PR TITLE
Add SimpleCacheTest::advanceTime()

### DIFF
--- a/src/SimpleCacheTest.php
+++ b/src/SimpleCacheTest.php
@@ -31,6 +31,21 @@ abstract class SimpleCacheTest extends TestCase
      */
     abstract public function createSimpleCache();
 
+    /**
+     * Advance time perceived by the cache for the purposes of testing TTL.
+     *
+     * The default implementation sleeps for the specified duration,
+     * but subclasses are encouraged to override this,
+     * adjusting a mocked time possibly set up in {@link createSimpleCache()},
+     * to speed up the tests.
+     *
+     * @param int $seconds
+     */
+    public function advanceTime($seconds)
+    {
+        sleep($seconds);
+    }
+
     protected function setUp()
     {
         $this->cache = $this->createSimpleCache();
@@ -142,12 +157,12 @@ abstract class SimpleCacheTest extends TestCase
         $result = $this->cache->set('key1', 'value', 1);
         $this->assertTrue($result, 'set() must return true if success');
         $this->assertEquals('value', $this->cache->get('key1'));
-        sleep(2);
+        $this->advanceTime(2);
         $this->assertNull($this->cache->get('key1'), 'Value must expire after ttl.');
 
         $this->cache->set('key2', 'value', new \DateInterval('PT1S'));
         $this->assertEquals('value', $this->cache->get('key2'));
-        sleep(2);
+        $this->advanceTime(2);
         $this->assertNull($this->cache->get('key2'), 'Value must expire after ttl.');
     }
 
@@ -236,13 +251,13 @@ abstract class SimpleCacheTest extends TestCase
         $this->cache->setMultiple(['key2' => 'value2', 'key3' => 'value3'], 1);
         $this->assertEquals('value2', $this->cache->get('key2'));
         $this->assertEquals('value3', $this->cache->get('key3'));
-        sleep(2);
+        $this->advanceTime(2);
         $this->assertNull($this->cache->get('key2'), 'Value must expire after ttl.');
         $this->assertNull($this->cache->get('key3'), 'Value must expire after ttl.');
 
         $this->cache->setMultiple(['key4' => 'value4'], new \DateInterval('PT1S'));
         $this->assertEquals('value4', $this->cache->get('key4'));
-        sleep(2);
+        $this->advanceTime(2);
         $this->assertNull($this->cache->get('key4'), 'Value must expire after ttl.');
     }
 


### PR DESCRIPTION
By default, these tests sleep for a total of eight seconds, significantly extending their duration beyond what would otherwise be required. To avoid this, extract the sleep call into a method which subclasses can override, allowing them to avoid this cost with an alternative implementation if possible.

---

Another iteration on the “the TTL tests are slow” issue, which others have tried to solve in the past – see also #49 and #94. Perhaps this PR will have more luck in getting merged? Unlike #49, it doesn’t add any new dependency (though it doesn’t by itself speed up the tests either – subclasses have to put in the work).