### PR TITLE
Rename ForwardCompatTestTrait

### DIFF
--- a/src/CachePoolTest.php
+++ b/src/CachePoolTest.php
@@ -14,11 +14,11 @@ namespace Cache\IntegrationTests;
 use PHPUnit\Framework\TestCase;
 use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
-use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
+use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 
 abstract class CachePoolTest extends TestCase
 {
-    use ForwardCompatTestTrait;
+    use SetUpTearDownTrait;
 
     /**
      * @type array with functionName => reason.

--- a/src/HierarchicalCachePoolTest.php
+++ b/src/HierarchicalCachePoolTest.php
@@ -13,14 +13,14 @@ namespace Cache\IntegrationTests;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Cache\CacheItemPoolInterface;
-use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
+use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
 abstract class HierarchicalCachePoolTest extends TestCase
 {
-    use ForwardCompatTestTrait;
+    use SetUpTearDownTrait;
 
     /**
      * @type array with functionName => reason.

--- a/src/SimpleCacheTest.php
+++ b/src/SimpleCacheTest.php
@@ -13,11 +13,11 @@ namespace Cache\IntegrationTests;
 
 use PHPUnit\Framework\TestCase;
 use Psr\SimpleCache\CacheInterface;
-use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
+use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 
 abstract class SimpleCacheTest extends TestCase
 {
-    use ForwardCompatTestTrait;
+    use SetUpTearDownTrait;
 
     /**
      * @type array with functionName => reason.

--- a/src/TaggableCachePoolTest.php
+++ b/src/TaggableCachePoolTest.php
@@ -13,14 +13,14 @@ namespace Cache\IntegrationTests;
 
 use Cache\TagInterop\TaggableCacheItemPoolInterface;
 use PHPUnit\Framework\TestCase;
-use Symfony\Bridge\PhpUnit\ForwardCompatTestTrait;
+use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
 abstract class TaggableCachePoolTest extends TestCase
 {
-    use ForwardCompatTestTrait;
+    use SetUpTearDownTrait;
 
     /**
      * @type array with functionName => reason.


### PR DESCRIPTION
The PhpUnitBridge trait has been rename in https://github.com/symfony/symfony/pull/32882