### PR TITLE
Replace `@expectedException` by $this->expectException()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.phpunit.result.cache
 composer.lock
 vendor

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ dist: trusty
 language: php
 sudo: true
 
+env:
+  global:
+    - SYMFONY_PHPUNIT_VERSION=5.7
+
 matrix:
   fast_finish: true
   include:
@@ -37,5 +41,5 @@ install:
   - composer update --prefer-source
 
 script:
-  - ./vendor/bin/phpunit --testsuite $SUITE
+  - ./vendor/bin/simple-phpunit --testsuite $SUITE
 

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,6 @@
         "cache/tag-interop": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8.35|^5.4.3",
         "cache/cache": "^1.0",
         "symfony/cache": "^3.4.31|^4.3.4|^5.0",
         "symfony/phpunit-bridge": "^4.4",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -41,4 +41,23 @@
       </exclude>
     </whitelist>
   </filter>
+
+  <listeners>
+    <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener">
+      <arguments>
+        <array>
+          <element key="time-sensitive">
+            <array>
+              <element key="0"><string>Cache\IntegrationTests</string></element>
+              <element key="2"><string>Symfony\Component\Cache</string></element>
+              <element key="3"><string>Symfony\Component\Cache\Tests\Fixtures</string></element>
+              <element key="4"><string>Symfony\Component\Cache\Tests\Traits</string></element>
+              <element key="5"><string>Symfony\Component\Cache\Traits</string></element>
+            </array>
+          </element>
+        </array>
+      </arguments>
+    </listener>
+  </listeners>
+
 </phpunit>

--- a/src/CachePoolTest.php
+++ b/src/CachePoolTest.php
@@ -559,7 +559,6 @@ abstract class CachePoolTest extends TestCase
     }
 
     /**
-     * @expectedException \Psr\Cache\InvalidArgumentException
      * @dataProvider invalidKeys
      */
     public function testGetItemInvalidKeys($key)
@@ -568,11 +567,11 @@ abstract class CachePoolTest extends TestCase
             $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
         }
 
+        $this->expectException('Psr\Cache\InvalidArgumentException');
         $this->cache->getItem($key);
     }
 
     /**
-     * @expectedException \Psr\Cache\InvalidArgumentException
      * @dataProvider invalidKeys
      */
     public function testGetItemsInvalidKeys($key)
@@ -581,11 +580,11 @@ abstract class CachePoolTest extends TestCase
             $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
         }
 
+        $this->expectException('Psr\Cache\InvalidArgumentException');
         $this->cache->getItems(['key1', $key, 'key2']);
     }
 
     /**
-     * @expectedException \Psr\Cache\InvalidArgumentException
      * @dataProvider invalidKeys
      */
     public function testHasItemInvalidKeys($key)
@@ -594,11 +593,11 @@ abstract class CachePoolTest extends TestCase
             $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
         }
 
+        $this->expectException('Psr\Cache\InvalidArgumentException');
         $this->cache->hasItem($key);
     }
 
     /**
-     * @expectedException \Psr\Cache\InvalidArgumentException
      * @dataProvider invalidKeys
      */
     public function testDeleteItemInvalidKeys($key)
@@ -607,11 +606,11 @@ abstract class CachePoolTest extends TestCase
             $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
         }
 
+        $this->expectException('Psr\Cache\InvalidArgumentException');
         $this->cache->deleteItem($key);
     }
 
     /**
-     * @expectedException \Psr\Cache\InvalidArgumentException
      * @dataProvider invalidKeys
      */
     public function testDeleteItemsInvalidKeys($key)
@@ -620,6 +619,7 @@ abstract class CachePoolTest extends TestCase
             $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
         }
 
+        $this->expectException('Psr\Cache\InvalidArgumentException');
         $this->cache->deleteItems(['key1', $key, 'key2']);
     }
 
@@ -742,8 +742,6 @@ abstract class CachePoolTest extends TestCase
     {
         if (isset($this->skippedTests[__FUNCTION__])) {
             $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
-
-            return;
         }
 
         $data = '';

--- a/src/HierarchicalCachePoolTest.php
+++ b/src/HierarchicalCachePoolTest.php
@@ -53,8 +53,6 @@ abstract class HierarchicalCachePoolTest extends TestCase
     {
         if (isset($this->skippedTests[__FUNCTION__])) {
             $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
-
-            return;
         }
 
         $user = 4711;
@@ -73,8 +71,6 @@ abstract class HierarchicalCachePoolTest extends TestCase
     {
         if (isset($this->skippedTests[__FUNCTION__])) {
             $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
-
-            return;
         }
 
         $item = $this->cache->getItem('|aaa|bbb|ccc|ddd');
@@ -117,8 +113,6 @@ abstract class HierarchicalCachePoolTest extends TestCase
     {
         if (isset($this->skippedTests[__FUNCTION__])) {
             $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
-
-            return;
         }
 
         $item = $this->cache->getItem('foo');
@@ -138,8 +132,6 @@ abstract class HierarchicalCachePoolTest extends TestCase
     {
         if (isset($this->skippedTests[__FUNCTION__])) {
             $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
-
-            return;
         }
 
         $item = $this->cache->getItem('|aaa|bbb');

--- a/src/SimpleCacheTest.php
+++ b/src/SimpleCacheTest.php
@@ -429,7 +429,6 @@ abstract class SimpleCacheTest extends TestCase
     }
 
     /**
-     * @expectedException \Psr\SimpleCache\InvalidArgumentException
      * @dataProvider invalidKeys
      */
     public function testGetInvalidKeys($key)
@@ -438,11 +437,11 @@ abstract class SimpleCacheTest extends TestCase
             $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
         }
 
+        $this->expectException('Psr\SimpleCache\InvalidArgumentException');
         $this->cache->get($key);
     }
 
     /**
-     * @expectedException \Psr\SimpleCache\InvalidArgumentException
      * @dataProvider invalidKeys
      */
     public function testGetMultipleInvalidKeys($key)
@@ -451,23 +450,21 @@ abstract class SimpleCacheTest extends TestCase
             $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
         }
 
+        $this->expectException('Psr\SimpleCache\InvalidArgumentException');
         $result = $this->cache->getMultiple(['key1', $key, 'key2']);
     }
 
-    /**
-     * @expectedException \Psr\SimpleCache\InvalidArgumentException
-     */
     public function testGetMultipleNoIterable()
     {
         if (isset($this->skippedTests[__FUNCTION__])) {
             $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
         }
 
+        $this->expectException('Psr\SimpleCache\InvalidArgumentException');
         $result = $this->cache->getMultiple('key');
     }
 
     /**
-     * @expectedException \Psr\SimpleCache\InvalidArgumentException
      * @dataProvider invalidKeys
      */
     public function testSetInvalidKeys($key)
@@ -476,11 +473,11 @@ abstract class SimpleCacheTest extends TestCase
             $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
         }
 
+        $this->expectException('Psr\SimpleCache\InvalidArgumentException');
         $this->cache->set($key, 'foobar');
     }
 
     /**
-     * @expectedException \Psr\SimpleCache\InvalidArgumentException
      * @dataProvider invalidArrayKeys
      */
     public function testSetMultipleInvalidKeys($key)
@@ -494,23 +491,21 @@ abstract class SimpleCacheTest extends TestCase
             yield $key => 'bar';
             yield 'key2' => 'baz';
         };
+        $this->expectException('Psr\SimpleCache\InvalidArgumentException');
         $this->cache->setMultiple($values());
     }
 
-    /**
-     * @expectedException \Psr\SimpleCache\InvalidArgumentException
-     */
     public function testSetMultipleNoIterable()
     {
         if (isset($this->skippedTests[__FUNCTION__])) {
             $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
         }
 
+        $this->expectException('Psr\SimpleCache\InvalidArgumentException');
         $this->cache->setMultiple('key');
     }
 
     /**
-     * @expectedException \Psr\SimpleCache\InvalidArgumentException
      * @dataProvider invalidKeys
      */
     public function testHasInvalidKeys($key)
@@ -519,11 +514,11 @@ abstract class SimpleCacheTest extends TestCase
             $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
         }
 
+        $this->expectException('Psr\SimpleCache\InvalidArgumentException');
         $this->cache->has($key);
     }
 
     /**
-     * @expectedException \Psr\SimpleCache\InvalidArgumentException
      * @dataProvider invalidKeys
      */
     public function testDeleteInvalidKeys($key)
@@ -532,11 +527,11 @@ abstract class SimpleCacheTest extends TestCase
             $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
         }
 
+        $this->expectException('Psr\SimpleCache\InvalidArgumentException');
         $this->cache->delete($key);
     }
 
     /**
-     * @expectedException \Psr\SimpleCache\InvalidArgumentException
      * @dataProvider invalidKeys
      */
     public function testDeleteMultipleInvalidKeys($key)
@@ -545,23 +540,21 @@ abstract class SimpleCacheTest extends TestCase
             $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
         }
 
+        $this->expectException('Psr\SimpleCache\InvalidArgumentException');
         $this->cache->deleteMultiple(['key1', $key, 'key2']);
     }
 
-    /**
-     * @expectedException \Psr\SimpleCache\InvalidArgumentException
-     */
     public function testDeleteMultipleNoIterable()
     {
         if (isset($this->skippedTests[__FUNCTION__])) {
             $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
         }
 
+        $this->expectException('Psr\SimpleCache\InvalidArgumentException');
         $this->cache->deleteMultiple('key');
     }
 
     /**
-     * @expectedException \Psr\SimpleCache\InvalidArgumentException
      * @dataProvider invalidTtl
      */
     public function testSetInvalidTtl($ttl)
@@ -570,11 +563,11 @@ abstract class SimpleCacheTest extends TestCase
             $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
         }
 
+        $this->expectException('Psr\SimpleCache\InvalidArgumentException');
         $this->cache->set('key', 'value', $ttl);
     }
 
     /**
-     * @expectedException \Psr\SimpleCache\InvalidArgumentException
      * @dataProvider invalidTtl
      */
     public function testSetMultipleInvalidTtl($ttl)
@@ -583,6 +576,7 @@ abstract class SimpleCacheTest extends TestCase
             $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
         }
 
+        $this->expectException('Psr\SimpleCache\InvalidArgumentException');
         $this->cache->setMultiple(['key' => 'value'], $ttl);
     }
 

--- a/src/TaggableCachePoolTest.php
+++ b/src/TaggableCachePoolTest.php
@@ -58,8 +58,6 @@ abstract class TaggableCachePoolTest extends TestCase
     {
         if (isset($this->skippedTests[__FUNCTION__])) {
             $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
-
-            return;
         }
 
         $this->cache->save($this->cache->getItem('key1')->set('value')->setTags(['tag1', 'tag2']));
@@ -84,8 +82,6 @@ abstract class TaggableCachePoolTest extends TestCase
     {
         if (isset($this->skippedTests[__FUNCTION__])) {
             $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
-
-            return;
         }
 
         $item = $this->cache->getItem('key')->set('value');
@@ -107,8 +103,6 @@ abstract class TaggableCachePoolTest extends TestCase
     {
         if (isset($this->skippedTests[__FUNCTION__])) {
             $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
-
-            return;
         }
 
         $item = $this->cache->getItem('key')->set('value');
@@ -122,45 +116,35 @@ abstract class TaggableCachePoolTest extends TestCase
         $this->assertCount(1, $item->getPreviousTags());
     }
 
-    /**
-     * @expectedException \Psr\Cache\InvalidArgumentException
-     */
     public function testTagAccessorWithEmptyTag()
     {
         if (isset($this->skippedTests[__FUNCTION__])) {
             $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
-
-            return;
         }
 
         $item = $this->cache->getItem('key')->set('value');
+        $this->expectException('Psr\Cache\InvalidArgumentException');
         $item->setTags(['']);
-        $this->cache->save($item);
     }
 
     /**
-     * @expectedException \Psr\Cache\InvalidArgumentException
      * @dataProvider invalidKeys
      */
     public function testTagAccessorWithInvalidTag($tag)
     {
         if (isset($this->skippedTests[__FUNCTION__])) {
             $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
-
-            return;
         }
 
         $item = $this->cache->getItem('key')->set('value');
+        $this->expectException('Psr\Cache\InvalidArgumentException');
         $item->setTags([$tag]);
-        $this->cache->save($item);
     }
 
     public function testTagAccessorDuplicateTags()
     {
         if (isset($this->skippedTests[__FUNCTION__])) {
             $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
-
-            return;
         }
 
         $item = $this->cache->getItem('key')->set('value');
@@ -179,8 +163,6 @@ abstract class TaggableCachePoolTest extends TestCase
     {
         if (isset($this->skippedTests[__FUNCTION__])) {
             $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
-
-            return;
         }
 
         $item = $this->cache->getItem('key')->set('value');
@@ -203,8 +185,6 @@ abstract class TaggableCachePoolTest extends TestCase
     {
         if (isset($this->skippedTests[__FUNCTION__])) {
             $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
-
-            return;
         }
 
         $item = $this->cache->getItem('key')->set('value');
@@ -226,8 +206,6 @@ abstract class TaggableCachePoolTest extends TestCase
     {
         if (isset($this->skippedTests[__FUNCTION__])) {
             $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
-
-            return;
         }
 
         $item = $this->cache->getItem('key')->set('value');
@@ -255,8 +233,6 @@ abstract class TaggableCachePoolTest extends TestCase
     {
         if (isset($this->skippedTests[__FUNCTION__])) {
             $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
-
-            return;
         }
 
         $item = $this->cache->getItem('key')->set('value');
@@ -285,8 +261,6 @@ abstract class TaggableCachePoolTest extends TestCase
     {
         if (isset($this->skippedTests[__FUNCTION__])) {
             $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
-
-            return;
         }
 
         $pool = $this->cache;


### PR DESCRIPTION
Allows running deprecations-free on PHPUnit 8, which we need on Symfony.