### PR TITLE
Move phpunit-bridge to require, bump PHP

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,14 +23,14 @@
         }
     ],
     "require":     {
-        "php": "^5.4|^7",
+        "php": ">=5.5.9",
         "psr/cache": "~1.0",
-        "cache/tag-interop": "^1.0"
+        "cache/tag-interop": "^1.0",
+        "symfony/phpunit-bridge": "^4.4|^5.0"
     },
     "require-dev": {
         "cache/cache": "^1.0",
         "symfony/cache": "^3.4.31|^4.3.4|^5.0",
-        "symfony/phpunit-bridge": "^4.4",
         "illuminate/cache": "^5.4|^5.5|^5.6",
         "tedivm/stash": "^0.14",
         "mockery/mockery": "^1.0"


### PR DESCRIPTION
symfony/phpunit-bridge is currently in require-dev, but that's wrong because the SetUpTearDown trait is used in the public interface of this library.

In turn, this forces a dependency on PHP >= 5.5.9 per phpunit-bridge's composer.json.