### PR TITLE
Add array conversion if getItems returns a Generator

### DIFF
--- a/src/CachePoolTest.php
+++ b/src/CachePoolTest.php
@@ -11,6 +11,7 @@
 
 namespace Cache\IntegrationTests;
 
+use Generator;
 use PHPUnit\Framework\TestCase;
 use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
@@ -581,7 +582,11 @@ abstract class CachePoolTest extends TestCase
         }
 
         $this->expectException('Psr\Cache\InvalidArgumentException');
-        $this->cache->getItems(['key1', $key, 'key2']);
+        $items = $this->cache->getItems(['key1', $key, 'key2']);
+
+        if ($items instanceof Generator) {
+            iterator_to_array($items);
+        }
     }
 
     /**


### PR DESCRIPTION
As per the spec, `getItems()` [may return a `\Traversable`](https://github.com/php-fig/cache/blob/master/src/CacheItemPoolInterface.php#L44), and [Generators implement `\Iterator`](https://www.php.net/manual/de/class.generator.php) so they are traversable.  
This means that I should be able to yield items from `getItems()` and the following implementation should be fulfilling the spec:
```php
public function getItems(array $keys = []): Traversable
{
        foreach ($keys as $key) {
            yield $this->getItem($key);
        }
}
```

This causes the [`testGetItemsInvalidKeys` test](https://github.com/php-cache/integration-tests/blob/e023fbe54c9821dfefbe04db0074ee8682f7f577/src/CachePoolTest.php#L577) to fail however, since keys won't actually be processed until the generator is iterated. By converting the generator to an array, the entire list of keys is processed.

This is a non-breaking change and allows libraries using Generators to pass the test suite.