### PR TITLE
Bump minimal version of "phpunit-bridge"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,12 +25,12 @@
     "require":     {
         "php": ">=5.5.9",
         "psr/cache": "~1.0",
-        "cache/tag-interop": "^1.0",
-        "symfony/phpunit-bridge": "^4.4|^5.0"
+        "cache/tag-interop": "^1.0"
     },
     "require-dev": {
         "cache/cache": "^1.0",
         "symfony/cache": "^3.4.31|^4.3.4|^5.0",
+        "symfony/phpunit-bridge": "^4.4|^5.0",
         "illuminate/cache": "^5.4|^5.5|^5.6",
         "tedivm/stash": "^0.14",
         "mockery/mockery": "^1.0"

--- a/composer.json
+++ b/composer.json
@@ -25,12 +25,12 @@
     "require":     {
         "php": ">=5.5.9",
         "psr/cache": "~1.0",
-        "cache/tag-interop": "^1.0"
+        "cache/tag-interop": "^1.0",
+        "symfony/phpunit-bridge": "^5.1"
     },
     "require-dev": {
         "cache/cache": "^1.0",
         "symfony/cache": "^3.4.31|^4.3.4|^5.0",
-        "symfony/phpunit-bridge": "^4.4|^5.0",
         "illuminate/cache": "^5.4|^5.5|^5.6",
         "tedivm/stash": "^0.14",
         "mockery/mockery": "^1.0"


### PR DESCRIPTION
The PR #107 break other projects (like symfony: https://travis-ci.com/github/symfony/symfony/jobs/422680568)

The issue is: when installing dependencies with flag `prefer-lowest`, composer pick an old buggy version of `phpunit-bridge` (symfony's bug actually)

This PR bump the minimal version to 5.1 which has the same requirements than 4.4  (https://packagist.org/packages/symfony/phpunit-bridge#5.1.x-dev) 