### PR TITLE
Remove dependency of phpunit-bridge

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,12 +25,12 @@
     "require":     {
         "php": ">=5.5.9",
         "psr/cache": "~1.0",
-        "cache/tag-interop": "^1.0",
-        "symfony/phpunit-bridge": "^5.1"
+        "cache/tag-interop": "^1.0"
     },
     "require-dev": {
         "cache/cache": "^1.0",
         "symfony/cache": "^3.4.31|^4.3.4|^5.0",
+        "symfony/phpunit-bridge": "^5.1",
         "illuminate/cache": "^5.4|^5.5|^5.6",
         "tedivm/stash": "^0.14",
         "mockery/mockery": "^1.0"

--- a/src/CachePoolTest.php
+++ b/src/CachePoolTest.php
@@ -14,12 +14,9 @@ namespace Cache\IntegrationTests;
 use PHPUnit\Framework\TestCase;
 use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
-use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 
 abstract class CachePoolTest extends TestCase
 {
-    use SetUpTearDownTrait;
-
     /**
      * @type array with functionName => reason.
      */
@@ -35,12 +32,18 @@ abstract class CachePoolTest extends TestCase
      */
     abstract public function createCachePool();
 
-    private function doSetUp()
+    /**
+     * @before
+     */
+    public function setupService()
     {
         $this->cache = $this->createCachePool();
     }
 
-    private function doTearDown()
+    /**
+     * @after
+     */
+    public function tearDownService()
     {
         if ($this->cache !== null) {
             $this->cache->clear();

--- a/src/HierarchicalCachePoolTest.php
+++ b/src/HierarchicalCachePoolTest.php
@@ -13,15 +13,12 @@ namespace Cache\IntegrationTests;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Cache\CacheItemPoolInterface;
-use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
 abstract class HierarchicalCachePoolTest extends TestCase
 {
-    use SetUpTearDownTrait;
-
     /**
      * @type array with functionName => reason.
      */
@@ -37,12 +34,18 @@ abstract class HierarchicalCachePoolTest extends TestCase
      */
     abstract public function createCachePool();
 
-    private function doSetUp()
+    /**
+     * @before
+     */
+    public function setupService()
     {
         $this->cache = $this->createCachePool();
     }
 
-    private function doTearDown()
+    /**
+     * @after
+     */
+    public function tearDownService()
     {
         if ($this->cache !== null) {
             $this->cache->clear();

--- a/src/SimpleCacheTest.php
+++ b/src/SimpleCacheTest.php
@@ -13,12 +13,9 @@ namespace Cache\IntegrationTests;
 
 use PHPUnit\Framework\TestCase;
 use Psr\SimpleCache\CacheInterface;
-use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 
 abstract class SimpleCacheTest extends TestCase
 {
-    use SetUpTearDownTrait;
-
     /**
      * @type array with functionName => reason.
      */
@@ -49,12 +46,18 @@ abstract class SimpleCacheTest extends TestCase
         sleep($seconds);
     }
 
-    private function doSetUp()
+    /**
+     * @before
+     */
+    public function setupService()
     {
         $this->cache = $this->createSimpleCache();
     }
 
-    private function doTearDown()
+    /**
+     * @after
+     */
+    public function tearDownService()
     {
         if ($this->cache !== null) {
             $this->cache->clear();

--- a/src/TaggableCachePoolTest.php
+++ b/src/TaggableCachePoolTest.php
@@ -13,15 +13,12 @@ namespace Cache\IntegrationTests;
 
 use Cache\TagInterop\TaggableCacheItemPoolInterface;
 use PHPUnit\Framework\TestCase;
-use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
 abstract class TaggableCachePoolTest extends TestCase
 {
-    use SetUpTearDownTrait;
-
     /**
      * @type array with functionName => reason.
      */
@@ -37,12 +34,18 @@ abstract class TaggableCachePoolTest extends TestCase
      */
     abstract public function createCachePool();
 
-    private function doSetUp()
+    /**
+     * @before
+     */
+    public function setupService()
     {
         $this->cache = $this->createCachePool();
     }
 
-    private function doTearDown()
+    /**
+     * @after
+     */
+    public function tearDownService()
     {
         if ($this->cache !== null) {
             $this->cache->clear();


### PR DESCRIPTION
This PR remove dependency on phpunit-bridge by replacing calls to setup/teardown by annotation (which exists since PHPUnit 4 https://github.com/sebastianbergmann/phpunit/blob/4.0.0/tests/_files/BeforeAndAfterTest.php#L14)