### PR TITLE
Remove deps from "require"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,9 +23,7 @@
         }
     ],
     "require":     {
-        "php": ">=5.5.9",
-        "psr/cache": "~1.0",
-        "cache/tag-interop": "^1.0"
+        "php": ">=5.5.9"
     },
     "require-dev": {
         "cache/cache": "^1.0",


### PR DESCRIPTION
Now that psr/cache v2 is released, we need to relax the constraints in "require" so that tested libs can bump to v2 and run tests with v2.

I don't think psr/cache needs to be listed as a dep of this package: because the purpose of this package is to test PSR-6 implementations, it's already a transitive dep for sure. Not putting any version constraint there delegates the constraint to tested libs, which LGTM.

About `cache/tag-interop`, it's already part of `cache/cache` in dev-mode. When used as a dep, `cache/tag-interop` adds extra constraints to the dep-tree, but the test suite is optional, so we can and should remove it also from "require", to relax deps.

Both changes will together allow `symfony/*` to run its tests with psr/cache v2.