### PR TITLE
Use `var` annotation along with key/value types

### DIFF
--- a/src/CachePoolTest.php
+++ b/src/CachePoolTest.php
@@ -18,7 +18,7 @@ use Psr\Cache\CacheItemPoolInterface;
 abstract class CachePoolTest extends TestCase
 {
     /**
-     * @type array with functionName => reason.
+     * @var array<string,string> with functionName => reason.
      */
     protected $skippedTests = [];
 

--- a/src/SimpleCacheTest.php
+++ b/src/SimpleCacheTest.php
@@ -17,7 +17,7 @@ use Psr\SimpleCache\CacheInterface;
 abstract class SimpleCacheTest extends TestCase
 {
     /**
-     * @type array with functionName => reason.
+     * @var array<string,string> with functionName => reason.
      */
     protected $skippedTests = [];
 


### PR DESCRIPTION
This will provide proper type definition for the array containing the skipped tests and their reasons.