### PR TITLE
Replaced unsupported Medium attribute on methods with Group('slow')

### DIFF
--- a/src/CachePoolTest.php
+++ b/src/CachePoolTest.php
@@ -15,7 +15,6 @@ use PHPUnit\Framework\Attributes\After;
 use PHPUnit\Framework\Attributes\Before;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\Medium;
 use PHPUnit\Framework\TestCase;
 use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
@@ -495,7 +494,7 @@ abstract class CachePoolTest extends TestCase
     /**
      * @medium
      */
-    #[Medium]
+    #[Group('slow')]
     public function testExpiration()
     {
         if (isset($this->skippedTests[__FUNCTION__])) {
@@ -870,7 +869,7 @@ abstract class CachePoolTest extends TestCase
     /**
      * @medium
      */
-    #[Medium]
+    #[Group('slow')]
     public function testHasItemReturnsFalseWhenDeferredItemIsExpired()
     {
         if (isset($this->skippedTests[__FUNCTION__])) {

--- a/src/SimpleCacheTest.php
+++ b/src/SimpleCacheTest.php
@@ -15,7 +15,6 @@ use PHPUnit\Framework\Attributes\After;
 use PHPUnit\Framework\Attributes\Before;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\Medium;
 use PHPUnit\Framework\TestCase;
 use Psr\SimpleCache\CacheInterface;
 
@@ -178,7 +177,7 @@ abstract class SimpleCacheTest extends TestCase
     /**
      * @medium
      */
-    #[Medium]
+    #[Group('slow')]
     public function testSetTtl()
     {
         if (isset($this->skippedTests[__FUNCTION__])) {
@@ -277,7 +276,7 @@ abstract class SimpleCacheTest extends TestCase
     /**
      * @medium
      */
-    #[Medium]
+    #[Group('slow')]
     public function testSetMultipleTtl()
     {
         if (isset($this->skippedTests[__FUNCTION__])) {


### PR DESCRIPTION
`#[Medium]` attribute can target only classes, `#[Group('medium')]` also cannot be applied.
`Group name "medium" is not allowed for method tests\integration\Cache\Psr6CacheTest::testExpiration`
Therefore i used `#[Group('slow')]`, or it can be dropped entirely, or a different name.