### PR TITLE
ensure compatibility with PHPUnit 12

### DIFF
--- a/src/CachePoolTest.php
+++ b/src/CachePoolTest.php
@@ -11,6 +11,11 @@
 
 namespace Cache\IntegrationTests;
 
+use PHPUnit\Framework\Attributes\After;
+use PHPUnit\Framework\Attributes\Before;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Medium;
 use PHPUnit\Framework\TestCase;
 use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
@@ -35,6 +40,7 @@ abstract class CachePoolTest extends TestCase
     /**
      * @before
      */
+    #[Before]
     public function setupService()
     {
         $this->cache = $this->createCachePool();
@@ -43,6 +49,7 @@ abstract class CachePoolTest extends TestCase
     /**
      * @after
      */
+    #[After]
     public function tearDownService()
     {
         if ($this->cache !== null) {
@@ -488,6 +495,7 @@ abstract class CachePoolTest extends TestCase
     /**
      * @medium
      */
+    #[Medium]
     public function testExpiration()
     {
         if (isset($this->skippedTests[__FUNCTION__])) {
@@ -567,6 +575,7 @@ abstract class CachePoolTest extends TestCase
     /**
      * @dataProvider invalidKeys
      */
+    #[DataProvider('invalidKeys')]
     public function testGetItemInvalidKeys($key)
     {
         if (isset($this->skippedTests[__FUNCTION__])) {
@@ -580,6 +589,7 @@ abstract class CachePoolTest extends TestCase
     /**
      * @dataProvider invalidKeys
      */
+    #[DataProvider('invalidKeys')]
     public function testGetItemsInvalidKeys($key)
     {
         if (isset($this->skippedTests[__FUNCTION__])) {
@@ -593,6 +603,7 @@ abstract class CachePoolTest extends TestCase
     /**
      * @dataProvider invalidKeys
      */
+    #[DataProvider('invalidKeys')]
     public function testHasItemInvalidKeys($key)
     {
         if (isset($this->skippedTests[__FUNCTION__])) {
@@ -606,6 +617,7 @@ abstract class CachePoolTest extends TestCase
     /**
      * @dataProvider invalidKeys
      */
+    #[DataProvider('invalidKeys')]
     public function testDeleteItemInvalidKeys($key)
     {
         if (isset($this->skippedTests[__FUNCTION__])) {
@@ -619,6 +631,7 @@ abstract class CachePoolTest extends TestCase
     /**
      * @dataProvider invalidKeys
      */
+    #[DataProvider('invalidKeys')]
     public function testDeleteItemsInvalidKeys($key)
     {
         if (isset($this->skippedTests[__FUNCTION__])) {
@@ -857,6 +870,7 @@ abstract class CachePoolTest extends TestCase
     /**
      * @medium
      */
+    #[Medium]
     public function testHasItemReturnsFalseWhenDeferredItemIsExpired()
     {
         if (isset($this->skippedTests[__FUNCTION__])) {

--- a/src/HierarchicalCachePoolTest.php
+++ b/src/HierarchicalCachePoolTest.php
@@ -11,6 +11,8 @@
 
 namespace Cache\IntegrationTests;
 
+use PHPUnit\Framework\Attributes\After;
+use PHPUnit\Framework\Attributes\Before;
 use PHPUnit\Framework\TestCase;
 use Psr\Cache\CacheItemPoolInterface;
 
@@ -37,6 +39,7 @@ abstract class HierarchicalCachePoolTest extends TestCase
     /**
      * @before
      */
+    #[Before]
     public function setupService()
     {
         $this->cache = $this->createCachePool();
@@ -45,6 +48,7 @@ abstract class HierarchicalCachePoolTest extends TestCase
     /**
      * @after
      */
+    #[After]
     public function tearDownService()
     {
         if ($this->cache !== null) {

--- a/src/SimpleCacheTest.php
+++ b/src/SimpleCacheTest.php
@@ -11,6 +11,11 @@
 
 namespace Cache\IntegrationTests;
 
+use PHPUnit\Framework\Attributes\After;
+use PHPUnit\Framework\Attributes\Before;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Medium;
 use PHPUnit\Framework\TestCase;
 use Psr\SimpleCache\CacheInterface;
 
@@ -49,6 +54,7 @@ abstract class SimpleCacheTest extends TestCase
     /**
      * @before
      */
+    #[Before]
     public function setupService()
     {
         $this->cache = $this->createSimpleCache();
@@ -57,6 +63,7 @@ abstract class SimpleCacheTest extends TestCase
     /**
      * @after
      */
+    #[After]
     public function tearDownService()
     {
         if ($this->cache !== null) {
@@ -171,6 +178,7 @@ abstract class SimpleCacheTest extends TestCase
     /**
      * @medium
      */
+    #[Medium]
     public function testSetTtl()
     {
         if (isset($this->skippedTests[__FUNCTION__])) {
@@ -269,6 +277,7 @@ abstract class SimpleCacheTest extends TestCase
     /**
      * @medium
      */
+    #[Medium]
     public function testSetMultipleTtl()
     {
         if (isset($this->skippedTests[__FUNCTION__])) {
@@ -441,6 +450,7 @@ abstract class SimpleCacheTest extends TestCase
     /**
      * @dataProvider invalidKeys
      */
+    #[DataProvider('invalidKeys')]
     public function testGetInvalidKeys($key)
     {
         if (isset($this->skippedTests[__FUNCTION__])) {
@@ -454,6 +464,7 @@ abstract class SimpleCacheTest extends TestCase
     /**
      * @dataProvider invalidKeys
      */
+    #[DataProvider('invalidKeys')]
     public function testGetMultipleInvalidKeys($key)
     {
         if (isset($this->skippedTests[__FUNCTION__])) {
@@ -477,6 +488,7 @@ abstract class SimpleCacheTest extends TestCase
     /**
      * @dataProvider invalidKeys
      */
+    #[DataProvider('invalidKeys')]
     public function testSetInvalidKeys($key)
     {
         if (isset($this->skippedTests[__FUNCTION__])) {
@@ -490,6 +502,7 @@ abstract class SimpleCacheTest extends TestCase
     /**
      * @dataProvider invalidArrayKeys
      */
+    #[DataProvider('invalidArrayKeys')]
     public function testSetMultipleInvalidKeys($key)
     {
         if (isset($this->skippedTests[__FUNCTION__])) {
@@ -518,6 +531,7 @@ abstract class SimpleCacheTest extends TestCase
     /**
      * @dataProvider invalidKeys
      */
+    #[DataProvider('invalidKeys')]
     public function testHasInvalidKeys($key)
     {
         if (isset($this->skippedTests[__FUNCTION__])) {
@@ -531,6 +545,7 @@ abstract class SimpleCacheTest extends TestCase
     /**
      * @dataProvider invalidKeys
      */
+    #[DataProvider('invalidKeys')]
     public function testDeleteInvalidKeys($key)
     {
         if (isset($this->skippedTests[__FUNCTION__])) {
@@ -544,6 +559,7 @@ abstract class SimpleCacheTest extends TestCase
     /**
      * @dataProvider invalidKeys
      */
+    #[DataProvider('invalidKeys')]
     public function testDeleteMultipleInvalidKeys($key)
     {
         if (isset($this->skippedTests[__FUNCTION__])) {
@@ -567,6 +583,7 @@ abstract class SimpleCacheTest extends TestCase
     /**
      * @dataProvider invalidTtl
      */
+    #[DataProvider('invalidTtl')]
     public function testSetInvalidTtl($ttl)
     {
         if (isset($this->skippedTests[__FUNCTION__])) {
@@ -580,6 +597,7 @@ abstract class SimpleCacheTest extends TestCase
     /**
      * @dataProvider invalidTtl
      */
+    #[DataProvider('invalidTtl')]
     public function testSetMultipleInvalidTtl($ttl)
     {
         if (isset($this->skippedTests[__FUNCTION__])) {
@@ -699,6 +717,7 @@ abstract class SimpleCacheTest extends TestCase
     /**
      * @dataProvider validKeys
      */
+    #[DataProvider('validKeys')]
     public function testSetValidKeys($key)
     {
         if (isset($this->skippedTests[__FUNCTION__])) {
@@ -712,6 +731,7 @@ abstract class SimpleCacheTest extends TestCase
     /**
      * @dataProvider validKeys
      */
+    #[DataProvider('validKeys')]
     public function testSetMultipleValidKeys($key)
     {
         if (isset($this->skippedTests[__FUNCTION__])) {
@@ -732,6 +752,7 @@ abstract class SimpleCacheTest extends TestCase
     /**
      * @dataProvider validData
      */
+    #[DataProvider('validData')]
     public function testSetValidData($data)
     {
         if (isset($this->skippedTests[__FUNCTION__])) {
@@ -745,6 +766,7 @@ abstract class SimpleCacheTest extends TestCase
     /**
      * @dataProvider validData
      */
+    #[DataProvider('validData')]
     public function testSetMultipleValidData($data)
     {
         if (isset($this->skippedTests[__FUNCTION__])) {

--- a/src/TaggableCachePoolTest.php
+++ b/src/TaggableCachePoolTest.php
@@ -12,6 +12,9 @@
 namespace Cache\IntegrationTests;
 
 use Cache\TagInterop\TaggableCacheItemPoolInterface;
+use PHPUnit\Framework\Attributes\After;
+use PHPUnit\Framework\Attributes\Before;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -37,6 +40,7 @@ abstract class TaggableCachePoolTest extends TestCase
     /**
      * @before
      */
+    #[Before]
     public function setupService()
     {
         $this->cache = $this->createCachePool();
@@ -45,6 +49,7 @@ abstract class TaggableCachePoolTest extends TestCase
     /**
      * @after
      */
+    #[After]
     public function tearDownService()
     {
         if ($this->cache !== null) {
@@ -133,6 +138,7 @@ abstract class TaggableCachePoolTest extends TestCase
     /**
      * @dataProvider invalidKeys
      */
+    #[DataProvider('invalidKeys')]
     public function testTagAccessorWithInvalidTag($tag)
     {
         if (isset($this->skippedTests[__FUNCTION__])) {


### PR DESCRIPTION
The `@after`, `@before`, `@dataProvider`, and `@medium` annotations are deprecated since PHPUnit 11. Since PHPUnit 10 one can use attributes to configure metadata instead.